### PR TITLE
Markdown friendly tables

### DIFF
--- a/src/main/java/org/creekservice/kafka/test/perf/util/Table.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/util/Table.java
@@ -65,7 +65,7 @@ public class Table {
 
         final String div =
                 widths.values().stream()
-                        .map(width -> "-".repeat(width + 2))
+                        .map(width -> "-".repeat(Math.max(3, width + 2)))
                         .collect(joining("|", "|", "|" + System.lineSeparator()));
 
         final String columnHeaders = String.format(format, headers.toArray());
@@ -73,7 +73,7 @@ public class Table {
         final String formattedRows =
                 rows.stream().map(row -> formattedRows(format, row)).collect(joining());
 
-        return div + columnHeaders + div + formattedRows + div;
+        return columnHeaders + div + formattedRows;
     }
 
     private static String formattedRows(final String format, final Row row) {


### PR DESCRIPTION
Change functional test so that output is a mark-down table, e.g.:

| Impl         | Overall                                 | DRAFT_03                          | DRAFT_04                            | DRAFT_06                            | DRAFT_07                            | DRAFT_2019_09                        | DRAFT_2020_12                         |
|--------------|-----------------------------------------|-----------------------------------|-------------------------------------|-------------------------------------|-------------------------------------|--------------------------------------|---------------------------------------|
| NetworkNt    | pass: r:4441 o:2016 / fail: r:225 o:302 |                                   | pass: r:579 o:228 / fail: r:10 o:19 | pass: r:771 o:272 / fail: r:21 o:35 | pass: r:851 o:446 / fail: r:25 o:84 | pass: r:1120 o:531 / fail: r:73 o:81 | pass: r:1120 o:539 / fail: r:96 o:83  |
|              | r:95.2% o:87.0% / r:4.8% f:13.0%        |                                   | r:98.3% o:92.3% / r:1.7% f:7.7%     | r:97.3% o:88.6% / r:2.7% f:11.4%    | r:97.1% o:84.2% / r:2.9% f:15.8%    | r:93.9% o:86.8% / r:6.1% f:13.2%     | r:92.1% o:86.7% / r:7.9% f:13.3%      |
|              | score: 93.1                             |                                   | score: 96.8                         | score: 95.2                         | score: 93.9                         | score: 92.1                          | score: 90.7                           |
| Skema        | pass: r:1189 o:500 / fail: r:27 o:122   |                                   |                                     |                                     |                                     |                                      | pass: r:1189 o:500 / fail: r:27 o:122 |
|              | r:97.8% o:80.4% / r:2.2% f:19.6%        |                                   |                                     |                                     |                                     |                                      | r:97.8% o:80.4% / r:2.2% f:19.6%      |
|              | score: 93.4                             |                                   |                                     |                                     |                                     |                                      | score: 93.4                           |
| Medeia       | pass: r:2244 o:943 / fail: r:13 o:141   |                                   | pass: r:585 o:209 / fail: r:4 o:38  | pass: r:787 o:269 / fail: r:5 o:38  | pass: r:872 o:465 / fail: r:4 o:65  |                                      |                                       |
|              | r:99.4% o:87.0% / r:0.6% f:13.0%        |                                   | r:99.3% o:84.6% / r:0.7% f:15.4%    | r:99.4% o:87.6% / r:0.6% f:12.4%    | r:99.5% o:87.7% / r:0.5% f:12.3%    |                                      |                                       |
|              | score: 96.3                             |                                   | score: 95.6                         | score: 96.4                         | score: 96.6                         |                                      |                                       |
| Snow         | pass: r:2817 o:1376 / fail: r:44 o:73   |                                   |                                     | pass: r:781 o:295 / fail: r:11 o:12 | pass: r:867 o:507 / fail: r:9 o:23  | pass: r:1169 o:574 / fail: r:24 o:38 |                                       |
|              | r:98.5% o:95.0% / r:1.5% f:5.0%         |                                   |                                     | r:98.6% o:96.1% / r:1.4% f:3.9%     | r:99.0% o:95.7% / r:1.0% f:4.3%     | r:98.0% o:93.8% / r:2.0% f:6.2%      |                                       |
|              | score: 97.6                             |                                   |                                     | score: 98.0                         | score: 98.1                         | score: 96.9                          |                                       |
| Everit       | pass: r:2198 o:950 / fail: r:59 o:134   |                                   | pass: r:579 o:218 / fail: r:10 o:29 | pass: r:768 o:279 / fail: r:24 o:28 | pass: r:851 o:453 / fail: r:25 o:77 |                                      |                                       |
|              | r:97.4% o:87.6% / r:2.6% f:12.4%        |                                   | r:98.3% o:88.3% / r:1.7% f:11.7%    | r:97.0% o:90.9% / r:3.0% f:9.1%     | r:97.1% o:85.5% / r:2.9% f:14.5%    |                                      |                                       |
|              | score: 94.9                             |                                   | score: 95.8                         | score: 95.4                         | score: 94.2                         |                                      |                                       |
| SchemaFriend | pass: r:5065 o:2325 / fail: r:34 o:104  | pass: r:433 o:104 / fail: r:0 o:7 | pass: r:588 o:233 / fail: r:1 o:14  | pass: r:789 o:293 / fail: r:3 o:14  | pass: r:873 o:509 / fail: r:3 o:21  | pass: r:1189 o:589 / fail: r:4 o:23  | pass: r:1193 o:597 / fail: r:23 o:25  |
|              | r:99.3% o:95.7% / r:0.7% f:4.3%         | r:100.0% o:93.7% / r:0.0% f:6.3%  | r:99.8% o:94.3% / r:0.2% f:5.7%     | r:99.6% o:95.4% / r:0.4% f:4.6%     | r:99.7% o:96.0% / r:0.3% f:4.0%     | r:99.7% o:96.2% / r:0.3% f:3.8%      | r:98.1% o:96.0% / r:1.9% f:4.0%       |
|              | score: 98.4                             | score: 98.4                       | score: 98.5                         | score: 98.6                         | score: 98.8                         | score: 98.8                          | score: 97.6                           |
| Vertx        | pass: r:3748 o:1704 / fail: r:126 o:307 |                                   | pass: r:578 o:223 / fail: r:11 o:24 |                                     | pass: r:858 o:435 / fail: r:18 o:95 | pass: r:1160 o:520 / fail: r:33 o:92 | pass: r:1152 o:526 / fail: r:64 o:96  |
|              | r:96.7% o:84.7% / r:3.3% f:15.3%        |                                   | r:98.1% o:90.3% / r:1.9% f:9.7%     |                                     | r:97.9% o:82.1% / r:2.1% f:17.9%    | r:97.2% o:85.0% / r:2.8% f:15.0%     | r:94.7% o:84.6% / r:5.3% f:15.4%      |
|              | score: 93.7                             |                                   | score: 96.2                         |                                     | score: 94.0                         | score: 94.2                          | score: 92.2                           |
| Justify      | pass: r:2139 o:1052 / fail: r:118 o:32  |                                   | pass: r:558 o:240 / fail: r:31 o:7  | pass: r:752 o:300 / fail: r:40 o:7  | pass: r:829 o:512 / fail: r:47 o:18 |                                      |                                       |
|              | r:94.8% o:97.0% / r:5.2% f:3.0%         |                                   | r:94.7% o:97.2% / r:5.3% f:2.8%     | r:94.9% o:97.7% / r:5.1% f:2.3%     | r:94.6% o:96.6% / r:5.4% f:3.4%     |                                      |                                       |
|              | score: 95.3                             |                                   | score: 95.3                         | score: 95.6                         | score: 95.1                         |                                      |                                       |

### Labels
Mark your PRs with the following labels, as appropriate:
- `breaking-change`: if the PR includes a breaking change
- `enhancement`: if the PR enables / completes a new feature
- `bug`: if the PR fixes a bug.
- `dependencies`: if the PR updates dependencies
- `documentation **`: If the PR doc-only changes
- `subtask **`: If the PR is only part of a new feature. Ensure final PR is marked with `enhancement`.
- `chore **`: a maintenance / non-feature released task of no interest to users.

Labels marked with `**` are excluded from release notes

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
