### PR TITLE
Remove snow from validation benchmark charts

### DIFF
--- a/docs/_docs/3. performance.md
+++ b/docs/_docs/3. performance.md
@@ -52,6 +52,11 @@ has fewer tests than draft `2020-12`.  As the benchmark measures the time taken 
 comparing performance across different draft specifications can be misleading.
 {: .notice--warning}
 
+**Note:**
+The graphs below exclude the `Snow` implementation, as it is orders of magnitude slower that other implementations.
+(The `Snow` implementation describes itself as a _reference_ implementation).
+{: .notice--warning}
+
 <div>
   <canvas id="validateChart_Draft_04"></canvas>
 </div>
@@ -132,8 +137,10 @@ Comparison of different implementations across specification versions may be mis
 
     const performanceData = {% include benchmark_results.json %};
 
-    function buildCharts(benchmarkName, title, elementIdPrefix, drafts){
-      let results = performanceData.filter(r => r.benchmark.includes(benchmarkName));
+    function buildCharts(benchmarkName, title, elementIdPrefix, drafts, includeSnow){
+      let results = performanceData
+        .filter(r => r.benchmark.includes(benchmarkName))
+        .filter(r => includeSnow || !r.benchmark.includes('_Snow'));
 
       drafts.forEach(function(draft) {
         let draftData = results.filter(r => r.benchmark.includes(draft)).sort(function(a, b) {
@@ -177,8 +184,8 @@ Comparison of different implementations across specification versions may be mis
       });
   } 
 
-  buildCharts('JsonValidateBenchmark', 'Validator Performance', 'validateChart_', ["Draft_04", "Draft_06", "Draft_07", "Draft_2019_09", "Draft_2020_12"]);
-  buildCharts('JsonSerdeBenchmark', 'Serde Performance', 'serdeChart_', ["Draft_07", "Draft_2020_12"]);
+  buildCharts('JsonValidateBenchmark', 'Validator Performance', 'validateChart_', ["Draft_04", "Draft_06", "Draft_07", "Draft_2019_09", "Draft_2020_12"], false);
+  buildCharts('JsonSerdeBenchmark', 'Serde Performance', 'serdeChart_', ["Draft_07", "Draft_2020_12"], true);
 </script>
 
 


### PR DESCRIPTION
fixes: #70

It's being removed as its orders of magnitude slower than other implementations and its inclusion makes the charts harder to read.
