### PR TITLE
Correct handling of optional format tests

### DIFF
--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/DevHarrelImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/DevHarrelImplementation.java
@@ -63,7 +63,15 @@ public class DevHarrelImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
+
+        /*
+        Implementation does not seem to currently provide a way to programmatically turn on format assertions.
+        Instead, they seem to be on-by-default, which is not inline with the draft 2020-12 spec.
+         */
 
         final Validator validator = validator(spec, additionalSchemas);
         final URI schemaUri = validator.registerSchema(schema);

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/EveritImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/EveritImplementation.java
@@ -70,7 +70,15 @@ public class EveritImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
+
+        /*
+        Implementation does not seem to currently provide a way to programmatically turn on format assertions.
+        Instead, they seem to be on-by-default, which is not inline with the draft 2020-12 spec.
+         */
 
         final Object schemaObject = parse(schema);
 

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/Implementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/Implementation.java
@@ -243,7 +243,13 @@ public interface Implementation {
      * @param spec the spec of the schema
      * @param additionalSchemas accessor to meta-schemas and JSON-Schema-Test-Suite 'remote'
      *     schemas.
+     * @param enableFormatAssertions Turn on format assertions for schemas versions where format
+     *     assertions should be off by default.
      * @return a validator instance that be can be used to validate, serialise and deserialise JSON.
      */
-    JsonValidator prepare(String schema, SchemaSpec spec, AdditionalSchemas additionalSchemas);
+    JsonValidator prepare(
+            String schema,
+            SchemaSpec spec,
+            AdditionalSchemas additionalSchemas,
+            boolean enableFormatAssertions);
 }

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/JacksonImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/JacksonImplementation.java
@@ -50,7 +50,10 @@ public class JacksonImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
         return new JsonValidator() {
             @Override
             public void validate(final String json) {

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/JustifyImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/JustifyImplementation.java
@@ -72,10 +72,14 @@ public class JustifyImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
 
         final JsonValidationService service = JsonValidationService.newInstance();
-        final JsonSchema parsedSchema = parseSchema(service, schema, spec, additionalSchemas);
+        final JsonSchema parsedSchema =
+                parseSchema(service, schema, spec, additionalSchemas, enableFormatAssertions);
         return new JsonValidator() {
             @Override
             public void validate(final String json) {
@@ -127,17 +131,19 @@ public class JustifyImplementation implements Implementation {
             final JsonValidationService service,
             final String schema,
             final SchemaSpec spec,
-            final AdditionalSchemas additionalSchemas) {
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
         final JsonSchemaResolver resolver =
                 uri -> {
                     final String s = additionalSchemas.load(uri);
-                    return parseSchema(service, s, spec, additionalSchemas);
+                    return parseSchema(service, s, spec, additionalSchemas, enableFormatAssertions);
                 };
 
         return service.createSchemaReaderFactoryBuilder()
                 .withDefaultSpecVersion(schemaVersion(spec))
                 .withSchemaResolver(resolver)
                 .withSchemaValidation(false)
+                .withStrictFormats(enableFormatAssertions)
                 .build()
                 .createSchemaReader(
                         new ByteArrayInputStream(schema.getBytes(StandardCharsets.UTF_8)))

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/MedeiaImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/MedeiaImplementation.java
@@ -82,11 +82,22 @@ public class MedeiaImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
         final JsonSchemaVersion version = schemaVersion(spec);
 
-        // Doesn't seem to be a way to reactively 'load' schema on demand:
-        // Only to provide them all, which means they ALL get parsed... slow!
+        /*
+        Implementation does not seem to currently provide a way to programmatically turn on format assertions.
+        Instead, they seem to be on-by-default, which is not inline with the draft 2020-12 spec.
+         */
+
+        /*
+        There doesn't seem to be a way to reactively 'load' schema on demand:
+        Only to provide them all upfront, which means they ALL get parsed... slow!
+         */
+
         final List<SchemaSource> schemas =
                 new ArrayList<>(additionalSchema(additionalSchemas, version));
         schemas.add(MetaSchemaSource.Companion.forVersion(version));

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/NetworkNtImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/NetworkNtImplementation.java
@@ -73,7 +73,16 @@ public class NetworkNtImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
+
+        /*
+        Implementation does not seem to currently provide a way to programmatically turn on format assertions.
+        Instead, they seem to be on-by-default, which is not inline with the draft 2020-12 spec.
+         */
+
         final JsonSchema parsedSchema = parseSchema(schema, spec, additionalSchemas);
 
         return new JsonValidator() {

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/SchemaFriendImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/SchemaFriendImplementation.java
@@ -66,9 +66,13 @@ public class SchemaFriendImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
+
         final Schema parsedSchema = parseSchema(schema, spec, additionalSchemas::load);
-        final Validator validator = new Validator(true);
+        final Validator validator = new Validator(enableFormatAssertions);
 
         return new JsonValidator() {
             @Override

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/SkemaImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/SkemaImplementation.java
@@ -66,7 +66,16 @@ public class SkemaImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
+
+        /*
+        Waiting on https://github.com/erosb/json-sKema/commit/ee8aca8c1452688dba485fa7cc7f3ab4fc85d74c being released
+        before we can make use of enableFormatAssertions
+         */
+
         final JsonValue schemaJson = new JsonParser(schema).parse();
 
         final SchemaLoader schemaLoader =

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/SnowImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/SnowImplementation.java
@@ -71,9 +71,16 @@ public class SnowImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
         final Validator validator =
-                createValidator(schema, spec, Optional.of(additionalSchemas.remotesDir()));
+                createValidator(
+                        schema,
+                        spec,
+                        Optional.of(additionalSchemas.remotesDir()),
+                        enableFormatAssertions);
 
         return new JsonValidator() {
             @Override
@@ -132,7 +139,10 @@ public class SnowImplementation implements Implementation {
 
     @SuppressWarnings({"CollectionContainsUrl", "OptionalUsedAsFieldOrParameterType"})
     private Validator createValidator(
-            final String schema, final SchemaSpec spec, final Optional<Path> remotesDir) {
+            final String schema,
+            final SchemaSpec spec,
+            final Optional<Path> remotesDir,
+            final boolean enableFormatAssertions) {
         try {
             final Map<URI, URL> knownURLs =
                     remotesDir.isPresent()
@@ -142,7 +152,7 @@ public class SnowImplementation implements Implementation {
                             : Map.of();
 
             final Options opts = new Options();
-            opts.set(Option.FORMAT, true);
+            opts.set(Option.FORMAT, enableFormatAssertions);
             opts.set(Option.CONTENT, true);
             opts.set(Option.DEFAULT_SPECIFICATION, schemaVersion(spec));
 

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/VertxImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/VertxImplementation.java
@@ -66,7 +66,16 @@ public class VertxImplementation implements Implementation {
 
     @Override
     public JsonValidator prepare(
-            final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
+            final String schema,
+            final SchemaSpec spec,
+            final AdditionalSchemas additionalSchemas,
+            final boolean enableFormatAssertions) {
+
+        /*
+        Implementation does not seem to currently provide a way to programmatically turn on format assertions.
+        Instead, they seem to be on-by-default, which is not inline with the draft 2020-12 spec.
+         */
+
         final Object decodedSchema = Json.decodeValue(schema);
 
         final JsonSchema parsedSchema =

--- a/src/main/java/org/creekservice/kafka/test/perf/performance/JsonSerdeBenchmark.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/performance/JsonSerdeBenchmark.java
@@ -218,7 +218,8 @@ public class JsonSerdeBenchmark {
                             ? impl.prepare(
                                     TestSchemas.DRAFT_7_SCHEMA,
                                     SchemaSpec.DRAFT_07,
-                                    new AdditionalSchemas(Map.of(), Path.of("")))
+                                    new AdditionalSchemas(Map.of(), Path.of("")),
+                                    false)
                             : null;
 
             this.validator2020 =
@@ -226,7 +227,8 @@ public class JsonSerdeBenchmark {
                             ? impl.prepare(
                                     TestSchemas.DRAFT_2020_SCHEMA,
                                     SchemaSpec.DRAFT_2020_12,
-                                    new AdditionalSchemas(Map.of(), Path.of("")))
+                                    new AdditionalSchemas(Map.of(), Path.of("")),
+                                    false)
                             : null;
         }
 

--- a/src/main/java/org/creekservice/kafka/test/perf/testsuite/JsonSchemaTestSuite.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/testsuite/JsonSchemaTestSuite.java
@@ -18,8 +18,10 @@ package org.creekservice.kafka.test.perf.testsuite;
 
 import static java.util.Objects.requireNonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -134,10 +136,16 @@ public final class JsonSchemaTestSuite {
                         .collect(Collectors.toList());
     }
 
+    @SuppressFBWarnings(
+            value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification = "Known not to be null")
     private JsonValidator prepareValidator(
             final SchemaSpec spec, final TestSuite suite, final Implementation implementation) {
         try {
-            return implementation.prepare(suite.schema(), spec, additionalSchemas);
+            final boolean format =
+                    Paths.get("format").equals(suite.filePath().getParent().getFileName());
+            return implementation.prepare(
+                    suite.schema(), spec, additionalSchemas, suite.optional() && format);
         } catch (final Throwable t) {
             final RuntimeException e = new RuntimeException("Failed to build validator", t);
             return new JsonValidator() {

--- a/src/test/java/org/creekservice/kafka/test/perf/implementations/ImplementationTest.java
+++ b/src/test/java/org/creekservice/kafka/test/perf/implementations/ImplementationTest.java
@@ -86,7 +86,7 @@ public class ImplementationTest {
         final TestData testData = testData(impl);
 
         // When:
-        impl.prepare(testData.schema, testData.spec, additionalSchemas);
+        impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
 
         // Then: did not throw.
     }
@@ -102,7 +102,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.schema, testData.spec, additionalSchemas);
+                impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
         final String badJson =
                 new String(validator.serialize(BAD_DECIMAL, false), StandardCharsets.UTF_8);
 
@@ -120,7 +120,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.schema, testData.spec, additionalSchemas);
+                impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
         final String goodJson =
                 new String(
                         validator.serialize(ModelState.TEST_MODEL, false), StandardCharsets.UTF_8);
@@ -145,7 +145,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.remoteSchema, testData.spec, additionalSchemas);
+                impl.prepare(testData.remoteSchema, testData.spec, additionalSchemas, false);
 
         // Then:
         validator.validate("100");
@@ -158,7 +158,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.schema, testData.spec, additionalSchemas);
+                impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
 
         // When:
         final byte[] bytes = validator.serialize(ModelState.TEST_MODEL, true);
@@ -177,7 +177,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.schema, testData.spec, additionalSchemas);
+                impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
 
         // Then:
         assertThrows(RuntimeException.class, () -> validator.serialize(BAD_DECIMAL, true));
@@ -189,7 +189,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.schema, testData.spec, additionalSchemas);
+                impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
 
         // When:
         validator.serialize(BAD_DECIMAL, false);
@@ -206,7 +206,7 @@ public class ImplementationTest {
         // Given:
         final TestData testData = testData(impl);
         final Implementation.JsonValidator validator =
-                impl.prepare(testData.schema, testData.spec, additionalSchemas);
+                impl.prepare(testData.schema, testData.spec, additionalSchemas, false);
         final byte[] serialized = validator.serialize(BAD_DECIMAL, false);
 
         // Then:


### PR DESCRIPTION
fixes: #79

Most implementations, especially older ones, tend not to offer control over format assertions.  However, a few did and correcting the test harness to only enable format assertions for tests under `optional/format` did improve their results.
