### PR TITLE
Add a 'last calculated' date to the results

### DIFF
--- a/docs/_docs/0. home.md
+++ b/docs/_docs/0. home.md
@@ -21,6 +21,9 @@ can be found on the main JSON Schema site's [implementations page <i class="fas 
 [<i class="fab fa-fw fa-github"/>&nbsp; on GitHub][GitHub-Project]{: .btn .btn--success}{:target="_blank"}
 {: .notice--warning}
 
+The results show in this micro-site were last calculated on {{ "now" | date: "%B %-d, %Y" }}
+{: .notice--info}
+
 The initial purpose of this comparison was to provide information to drive the decision on which JSON validation library Creek should make use of.
 However, the code and the results are shared to help others who are faced with a similar decision.
 

--- a/docs/_docs/1. implementations.md
+++ b/docs/_docs/1. implementations.md
@@ -10,6 +10,9 @@ classes: wide
 
 See below for an up-to-date list of the JVM based JSON Validator implementations covered by this performance and functionality comparison.
 
+This table was last updated {{ "now" | date: "%B %-d, %Y" }}
+{: .notice--info}
+
 <div>
  <table id="implsTable"></table>
 </div>

--- a/docs/_docs/2. functional.md
+++ b/docs/_docs/2. functional.md
@@ -28,6 +28,9 @@ Though, these are being worked on.  Ultimately, this project should replace this
 
 ## Results
 
+These results where last updated {{ "now" | date: "%B %-d, %Y" }}
+{: .notice--info}
+
 For each schema specification an implementation supports, the number of test cases that pass and fail is tracked, 
 split into those covering _required_ vs _optional_ features.
 

--- a/docs/_docs/3. performance.md
+++ b/docs/_docs/3. performance.md
@@ -58,6 +58,9 @@ The graphs below exclude the `Snow` implementation, as it is orders of magnitude
 (The `Snow` implementation describes itself as a _reference_ implementation).
 {: .notice--warning}
 
+These results where last updated {{ "now" | date: "%B %-d, %Y" }}
+{: .notice--info}
+
 <div id="ValidateCharts"></div>
 
 ### Serde benchmark
@@ -88,6 +91,9 @@ then validate & deserialize the simple Java object, with the following caveats:
 Newer schema versions are more feature rich, and this can come at a cost.
 Comparison of different implementations across specification versions may be misleading. 
 {: .notice--warning}
+
+These results where last updated {{ "now" | date: "%B %-d, %Y" }}
+{: .notice--info}
 
 <div id="SerdeCharts"></div>
 


### PR DESCRIPTION
The 'Updated' date is calculated from the last git update time, which doesn't reflect the date the benchmarks and functional test runs where done.

This can makes it clear _when_ the performance and functional comparison was actually run.
