### PR TITLE
Enable format assertions for optional/ecmascript-regex.json

### DIFF
--- a/src/main/java/org/creekservice/kafka/test/perf/testsuite/JsonSchemaTestSuite.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/testsuite/JsonSchemaTestSuite.java
@@ -143,7 +143,9 @@ public final class JsonSchemaTestSuite {
             final SchemaSpec spec, final TestSuite suite, final Implementation implementation) {
         try {
             final boolean format =
-                    Paths.get("format").equals(suite.filePath().getParent().getFileName());
+                    Paths.get("format").equals(suite.filePath().getParent().getFileName())
+                            || Paths.get("ecmascript-regex.json")
+                                    .equals(suite.filePath().getFileName());
             return implementation.prepare(
                     suite.schema(), spec, additionalSchemas, suite.optional() && format);
         } catch (final Throwable t) {


### PR DESCRIPTION
Closes #190

This enabled format assertions for `optional/ecmascript-regex.json` as the `\\a is not an ECMA 262 control escape test` is a format "format": "regex" that expects the result to be invalid.

This also upgrades `com.networknt:json-schema-validator` to `1.4.2` as this version passes the "format": "regex" test.