### PR TITLE
Bump com.networknt:json-schema-validator from 1.4.0 to 1.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
 
     implementation("net.jimblackler.jsonschemafriend:core:0.12.4")
 
-    implementation("com.networknt:json-schema-validator:1.4.0")
+    implementation("com.networknt:json-schema-validator:1.4.2")
 
     implementation("com.qindesign:snowy-json:0.16.0")
     runtimeOnly("org.glassfish:jakarta.json:2.0.0:module")

--- a/src/main/java/org/creekservice/kafka/test/perf/implementations/NetworkNtImplementation.java
+++ b/src/main/java/org/creekservice/kafka/test/perf/implementations/NetworkNtImplementation.java
@@ -32,6 +32,7 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.regex.JoniRegularExpressionFactory;
 import java.awt.Color;
 import java.io.IOException;
 import java.util.Map;
@@ -143,10 +144,12 @@ public class NetworkNtImplementation implements Implementation {
 
     private JsonSchema parseSchema(
             final String schema, final SchemaSpec spec, final AdditionalSchemas additionalSchemas) {
-        final SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         // By default, the library uses the JDK regular expression implementation which is not ECMA
         // 262 compliant. This requires the joni dependency
-        config.setEcma262Validator(true);
+        final SchemaValidatorsConfig config =
+                SchemaValidatorsConfig.builder()
+                        .regularExpressionFactory(JoniRegularExpressionFactory.getInstance())
+                        .build();
         return JsonSchemaFactory.getInstance(
                         schemaVersion(spec),
                         builder ->


### PR DESCRIPTION
Upgrades com.networknt:json-schema-validator from 1.4.0 to 1.4.2 and replaces deprecated configuration.