### PR TITLE
Fix deprecated `gradle-home-cache-cleanup` action parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          cache-cleanup: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - name: Build
         run: ./gradlew build jacocoTestReport
       - name: Upload coverage to Codecov
@@ -100,7 +101,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          cache-cleanup: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - name: Build
         run: ./gradlew.bat build -PexcludeContainerised
       - name: Upload reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
       - name: Build
         run: ./gradlew build jacocoTestReport
       - name: Upload coverage to Codecov
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
       - name: Build
         run: ./gradlew.bat build -PexcludeContainerised
       - name: Upload reports

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          cache-cleanup: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - name: Extract implementation info
         run: ./gradlew --quiet extractImplementations
       - name: Add results to step summary
@@ -54,7 +55,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          cache-cleanup: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - name: Run functional tests
         run: ./gradlew --quiet runFunctionalTests
       - name: Add results to step summary    
@@ -81,7 +83,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          cache-cleanup: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - if: github.event_name == 'pull_request'
         name: Run performance smoke benchmarks
         run: ./gradlew --quiet runValidateBenchmarkSmokeTest
@@ -110,7 +113,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          cache-cleanup: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - if: github.event_name == 'pull_request'
         name: Run performance smoke benchmarks
         run: ./gradlew --quiet runSerdeBenchmarkSmokeTest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
       - name: Extract implementation info
         run: ./gradlew --quiet extractImplementations
       - name: Add results to step summary
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
       - name: Run functional tests
         run: ./gradlew --quiet runFunctionalTests
       - name: Add results to step summary    
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
       - if: github.event_name == 'pull_request'
         name: Run performance smoke benchmarks
         run: ./gradlew --quiet runValidateBenchmarkSmokeTest
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
       - if: github.event_name == 'pull_request'
         name: Run performance smoke benchmarks
         run: ./gradlew --quiet runSerdeBenchmarkSmokeTest


### PR DESCRIPTION
## Summary

Replaces the deprecated `gradle-home-cache-cleanup` input parameter with `cache-cleanup` in all `gradle/actions/setup-gradle` usages.

This resolves the deprecation warning seen in [run 25078126414](https://github.com/creek-service/json-schema-validation-comparison/actions/runs/25078126414):

```
DEPRECATION: The `gradle-home-cache-cleanup` input parameter has been replaced by `cache-cleanup`.
See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-gradle-home-cache-cleanup-input-parameter-has-been-replaced-by-cache-cleanup
```

## Changes

- `.github/workflows/build.yml`: 2 occurrences fixed (`build_linux`, `build_windows` jobs)
- `.github/workflows/gh-pages.yml`: 4 occurrences fixed (`get_impls`, `run_functional`, `run_validate_benchmark`, `run_serde_benchmark` jobs)